### PR TITLE
Bump esbuild to 0.28.1

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -10,20 +10,24 @@ if you want to view the source, please visit the github repository of this plugi
 
 const prod = process.argv[2] === 'production';
 
-esbuild
-	.build({
-		banner: {
-			js: banner,
-		},
-		entryPoints: ['src/main.ts'],
-		bundle: true,
-		external: ['obsidian', 'electron', ...builtins],
-		format: 'cjs',
-		watch: !prod,
-		target: 'es2016',
-		logLevel: 'info',
-		sourcemap: prod ? false : 'inline',
-		treeShaking: true,
-		outfile: 'main.js',
-	})
-	.catch(() => process.exit(1));
+const context = await esbuild.context({
+	banner: {
+		js: banner,
+	},
+	entryPoints: ['src/main.ts'],
+	bundle: true,
+	external: ['obsidian', 'electron', ...builtins],
+	format: 'cjs',
+	target: 'es2016',
+	logLevel: 'info',
+	sourcemap: prod ? false : 'inline',
+	treeShaking: true,
+	outfile: 'main.js',
+});
+
+if (prod) {
+	await context.rebuild();
+	process.exit(0);
+} else {
+	await context.watch();
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"@typescript-eslint/eslint-plugin": "^5.8.1",
 		"@typescript-eslint/parser": "^5.8.1",
 		"builtin-modules": "^3.2.0",
-		"esbuild": "~0.13.12",
+		"esbuild": "0.28.1",
 		"eslint": "^8.5.0",
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-react": "^7.28.0",


### PR DESCRIPTION
Fixes a moderate Dependabot alert (GHSA-67mh-4wv8-2f99, dev-server CORS;
patched in 0.25.0). The removed 'watch' option is migrated to the esbuild
0.17+ context API. Production build verified locally.
