### PR TITLE
ci: tier Dependabot cooldown by semver level

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,25 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    # Dependabot resolves versions itself, so .npmrc's minimum-release-age does
-    # not apply to its PRs. Mirror it: wait 7 days after a release before proposing it.
+    # Security updates bypass cooldown and arrive as soon as an advisory is published.
+    # Version updates wait for a release to age: patches barely (they rarely break, and
+    # batching them only grows the diff), minors until they have matured.
     cooldown:
-      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 30
+      semver-major-days: 60
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
+    # Security updates bypass cooldown and arrive as soon as an advisory is published.
+    # Version updates wait for a release to age: patches barely (they rarely break, and
+    # batching them only grows the diff), minors until they have matured.
     cooldown:
-      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 30
+      semver-major-days: 60
     # Majors we bump by hand, on purpose:
     ignore:
       # 7.x is the Go-based rewrite (tsgo); stay on the 5.x line until tooling catches up.


### PR DESCRIPTION
Tune Dependabot cadence by update type:

- **Security updates**: unchanged — they ignore `schedule`/`cooldown` and open as soon as an advisory is published (Dependabot security updates are enabled on this repo).
- **Patch**: `semver-patch-days: 7` — low risk; waiting longer only grows the diff to review.
- **Minor**: `semver-minor-days: 30` — let releases mature before adopting.
- **Major**: `semver-major-days: 60`.

Schedule stays/becomes `weekly`: cooldown (release age), not schedule (check frequency), is what controls how "seasoned" a version must be, so updates trickle in weekly as they clear cooldown instead of arriving in a monthly batch.

https://claude.ai/code/session_01HkPBr8tF6q2MeCG3VwksLQ