### PR TITLE
Tighten Dependabot and CI supply-chain policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,8 @@ updates:
       day: saturday
       time: "03:00"
       timezone: Asia/Tokyo
-    # Security updates bypass cooldown and arrive as soon as an advisory is published.
     # github-actions does not support per-semver cooldown (semver-*-days are ignored and
-    # Dependabot silently falls back to its 3-day default), so use a flat one-week cooldown.
+    # Dependabot silently falls back to its 3-day default), so use a flat cooldown.
     cooldown:
       default-days: 7
 
@@ -20,13 +19,22 @@ updates:
       day: saturday
       time: "03:00"
       timezone: Asia/Tokyo
-    # Security updates bypass cooldown and arrive as soon as an advisory is published.
-    # Version updates wait for a release to age: patches barely (they rarely break, and
-    # batching them only grows the diff), minors until they have matured.
+    # Cooldown applies to version updates only. Security updates skip it, but they still
+    # have to pass `minimum-release-age` in .npmrc, which pnpm enforces when Dependabot
+    # regenerates the lockfile: a fix version younger than that gate fails to resolve and
+    # the security PR errors. That is deliberate. A fix version gets no special trust; wait
+    # for it to age unless the advisory is severe and the vulnerable path is actually reachable
+    # from this plugin. In that case bump by hand with `--config.minimum-release-age=0` and say
+    # so in the PR body.
+    #
+    # Days are chosen by the bump type from the *installed* version to the candidate, so from
+    # 1.2.0 both 1.3.0 and 1.3.1 count as minor. A longer minor cooldown therefore never
+    # picks the patched 1.3.1 over 1.3.0 (1.3.1 is always younger); it only delays 1.3.0.
+    # So keep patch and minor at the same length as the .npmrc age gate (7 days), and delay
+    # majors only to leave time for peer dependencies to catch up and to plan the migration.
     cooldown:
-      semver-patch-days: 7
-      semver-minor-days: 30
-      semver-major-days: 60
+      default-days: 7
+      semver-major-days: 30
     # Majors we bump by hand, on purpose:
     ignore:
       # 7.x is the Go-based rewrite (tsgo); stay on the 5.x line until tooling catches up.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
   push:
     branches: ["main"]
+  # 週次で main を検査する。commit がない期間でも `pnpm audit` が新しい advisory を拾えるようにするため
+  # (Dependabot は親 package が exact pin する transitive 依存の advisory を PR にできないことがある)。
+  # 土曜 03:00 JST = 金曜 18:00 UTC。Dependabot (土曜 03:00 JST) と同じタイミングにそろえる。
+  schedule:
+    - cron: "0 18 * * 5"
 
 permissions:
   contents: read
@@ -24,6 +29,12 @@ jobs:
           install: true
           cache: true
       - run: pnpm install --frozen-lockfile
+      # mise.toml と package.json (packageManager / engines / @types/node) の pnpm・Node version がずれていないか
+      - run: node scripts/check-toolchain.mjs
+      # 全 action が commit SHA に pin されているか (tag 参照を新しく足すと落ちる)
+      - run: node scripts/check-actions-pinned.mjs
+      # 全部 devDependencies (一部は main.js に bundle される) なので全体を high 以上で止める
+      - run: pnpm audit --audit-level=high
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm build

--- a/package.json
+++ b/package.json
@@ -1,30 +1,31 @@
 {
-	"name": "obsidian-sample-plugin",
-	"version": "0.12.0",
-	"description": "This is a sample plugin for Obsidian (https://obsidian.md)",
-	"main": "main.js",
-	"packageManager": "pnpm@10.33.2",
-	"engines": {
-		"node": ">=22"
-	},
-	"scripts": {
-		"fix:format": "biome format --write src",
-		"lint:format": "biome format --check src",
-		"fix:lint": "biome lint --write src",
-		"lint": "biome check src",
-		"typecheck": "tsc --noEmit",
-		"fix": "biome check --write src",
-		"dev": "node esbuild.config.mjs",
-		"build": "node esbuild.config.mjs production"
-	},
-	"keywords": [],
-	"author": "",
-	"license": "MIT",
-	"devDependencies": {
-		"@biomejs/biome": "2.5.12",
-		"@types/node": "24.13.3",
-		"esbuild": "0.28.2",
-		"obsidian": "^1.13.1",
-		"typescript": "5.9.3"
-	}
+  "name": "obsidian-sample-plugin",
+  "version": "0.12.0",
+  "description": "This is a sample plugin for Obsidian (https://obsidian.md)",
+  "main": "main.js",
+  "packageManager": "pnpm@10.33.2",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "scripts": {
+    "fix:format": "biome format --write src",
+    "lint:format": "biome format --check src",
+    "fix:lint": "biome lint --write src",
+    "lint": "biome check src",
+    "typecheck": "tsc --noEmit",
+    "fix": "biome check --write src",
+    "dev": "node esbuild.config.mjs",
+    "build": "node esbuild.config.mjs production",
+    "check": "node scripts/check-toolchain.mjs && node scripts/check-actions-pinned.mjs && pnpm lint && pnpm typecheck && pnpm build"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@biomejs/biome": "2.5.12",
+    "@types/node": "24.13.3",
+    "esbuild": "0.28.2",
+    "obsidian": "^1.13.1",
+    "typescript": "5.9.3"
+  }
 }

--- a/scripts/check-actions-pinned.mjs
+++ b/scripts/check-actions-pinned.mjs
@@ -1,0 +1,31 @@
+// .github/workflows 内の `uses:` が全て commit SHA (40桁 hex) に pin されているか検査する。
+// Dependabot は既存の pin を更新するだけで、新しく足された tag 参照 (例: actions/checkout@v7) は指摘しない。
+// tag は後から別の commit に付け替えられるので、review していない code が CI で動くのを防ぐ。
+// ローカル action (./path) と docker:// は対象外。pin の更新は `mise run pin-actions:update`。
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const dir = new URL("../.github/workflows/", import.meta.url);
+const files = readdirSync(dir).filter((f) => /\.ya?ml$/.test(f));
+const errors = [];
+
+for (const file of files) {
+  const lines = readFileSync(join(dir.pathname, file), "utf8").split("\n");
+  lines.forEach((line, i) => {
+    const m = line.match(/^\s*-?\s*uses:\s*["']?([^"'\s#]+)/);
+    if (!m) return;
+    const ref = m[1];
+    if (ref.startsWith("./") || ref.startsWith("docker://")) return;
+    if (!/^[\w.-]+\/[\w.-]+(\/[^@]+)?@[0-9a-f]{40}$/.test(ref)) {
+      errors.push(`${file}:${i + 1}: ${ref}`);
+    }
+  });
+}
+
+if (errors.length > 0) {
+  console.error("actions-pinned: commit SHA に pin されていない action があります:");
+  for (const e of errors) console.error(`  ${e}`);
+  console.error("  `mise run pin-actions` で pin できます。");
+  process.exit(1);
+}
+console.log(`actions-pinned: ok (${files.length} workflow)`);

--- a/scripts/check-toolchain.mjs
+++ b/scripts/check-toolchain.mjs
@@ -1,0 +1,44 @@
+// mise.toml と package.json の toolchain version が一致するか検査する。
+// Dependabot は mise.toml を扱えないので、pnpm / Node を上げるときは両方を手で更新する必要がある。
+// ずれると CI (mise) とローカル (packageManager / engines) で違う version が動くので、ここで止める。
+import { readFileSync } from "node:fs";
+
+const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const mise = readFileSync(new URL("../mise.toml", import.meta.url), "utf8");
+
+function miseTool(name) {
+  const tools = mise.match(/^\[tools\]\n([\s\S]*?)(?=^\[|(?![\s\S]))/m)?.[1] ?? "";
+  return tools.match(new RegExp(`^${name}\\s*=\\s*"([^"]+)"`, "m"))?.[1];
+}
+
+const errors = [];
+
+const pnpmFromPkg = pkg.packageManager?.match(/^pnpm@(\d+\.\d+\.\d+)$/)?.[1];
+const pnpmFromMise = miseTool("pnpm");
+if (!pnpmFromPkg)
+  errors.push(`package.json の packageManager が "pnpm@x.y.z" 形式ではない: ${pkg.packageManager}`);
+if (!pnpmFromMise) errors.push("mise.toml の [tools] に pnpm がない");
+if (pnpmFromPkg && pnpmFromMise && pnpmFromPkg !== pnpmFromMise) {
+  errors.push(`pnpm version がずれている: package.json=${pnpmFromPkg} mise.toml=${pnpmFromMise}`);
+}
+
+// engines.node は ">=24.0.0" / ">=24" / "24.x" のどれでも major だけ見る
+const nodeMajorFromPkg = pkg.engines?.node?.match(/(\d+)/)?.[1];
+const nodeFromMise = miseTool("node");
+if (!nodeMajorFromPkg)
+  errors.push(`package.json の engines.node から major を読めない: ${pkg.engines?.node}`);
+if (!nodeFromMise) errors.push("mise.toml の [tools] に node がない");
+if (nodeMajorFromPkg && nodeFromMise && nodeFromMise.split(".")[0] !== nodeMajorFromPkg) {
+  errors.push(`Node major がずれている: package.json engines=${nodeMajorFromPkg} mise.toml=${nodeFromMise}`);
+}
+
+const typesNodeMajor = pkg.devDependencies?.["@types/node"]?.match(/(\d+)/)?.[1];
+if (typesNodeMajor && nodeMajorFromPkg && typesNodeMajor !== nodeMajorFromPkg) {
+  errors.push(`@types/node の major がずれている: @types/node=${typesNodeMajor} engines=${nodeMajorFromPkg}`);
+}
+
+if (errors.length > 0) {
+  for (const e of errors) console.error(`toolchain: ${e}`);
+  process.exit(1);
+}
+console.log(`toolchain: ok (pnpm ${pnpmFromPkg}, node ${nodeFromMise})`);


### PR DESCRIPTION
harden-deps skill の基準に合わせ、Dependabot と CI の supply chain 設定を揃える (qawatake/secret-handoff#12 と同じ方針)。

**a. npm の cooldown を「7 日、major のみ 30 日」にした (原則 i)**
旧: patch 7 / minor 30 / major 60。Dependabot は cooldown 日数を「入っている version から候補への bump 種別」で決めるため、1.2.0 から見ると 1.3.0 も 1.3.1 も minor 扱い。minor を長くしても若い 1.3.1 が選ばれることはなく、1.3.0 が遅れて来るだけ。patch と minor を `.npmrc` の `minimum-release-age` (7 日) に揃え、major だけ移行準備のために 30 日遅らせる。

**b. security fix version も age gate を通す方針を明文化した (原則 k)**
security update は cooldown を飛ばすが、pnpm が lockfile を作り直すときに `.npmrc` の `minimum-release-age` は効く。公開 7 日未満の fix version を指す security PR は失敗するが、これは意図した挙動。旧コメントの「advisory 公開と同時に届く」は実態と違うので差し替えた。

**c. CI を週次でも走らせ、`pnpm audit --audit-level=high` を追加した (原則 g, m)**
`pnpm audit` が無く、push / PR が無い期間は advisory に気づけなかった。Dependabot と同じ土曜 03:00 JST に schedule 実行する。全部 devDependencies (一部は main.js に bundle される) なので全体を high 以上で止める。

**d. Actions が commit SHA に pin されているかを CI で検査する (原則 l)**
`scripts/check-actions-pinned.mjs`。Dependabot は既存の pin を更新するだけで、新しく足した tag 参照は指摘しない。

**e. pnpm / Node の version が mise.toml と package.json でずれていないかを CI で検査する (原則 n)**
`scripts/check-toolchain.mjs`。あわせて `engines.node` を `>=22` から mise の Node 24 に合わせて `>=24.0.0` にした (CI もローカルも 24 で動いている)。

**f. `pnpm check` script を追加**
CI と同じ一式を手元で流せるようにした。

## 検証

- `pnpm install --frozen-lockfile`、check script 2 つ、`pnpm lint` / `typecheck` / `build`、`pnpm audit --audit-level=high` が通る
- pin check は `actions/checkout@v7` を含む workflow で exit 1 になることを確認した
- check script は harden-deps skill の asset と byte 単位で同一
