### PR TITLE
Pin dependency ranges to the resolved versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@biomejs/biome": "2.5.12",
     "@types/node": "24.13.3",
     "esbuild": "0.28.2",
-    "obsidian": "^1.13.1",
+    "obsidian": "1.13.1",
     "typescript": "5.9.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: 0.28.2
         version: 0.28.2
       obsidian:
-        specifier: ^1.13.1
+        specifier: 1.13.1
         version: 1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
       typescript:
         specifier: 5.9.3


### PR DESCRIPTION
**a. 何を変えたか**
`package.json` に残っていた `^` の範囲指定 1 件を、`pnpm-lock.yaml` が既に解決している version にそのまま書き換えた。upgrade は一切していない。

**b. 依存ツリーは変わっていない**
lockfile の差分は specifier 行のみ (2 行)。version / resolution / integrity の変更は 0 行。

**c. なぜ exact pin か (原則 a)**
範囲指定のままだと、lockfile を作り直す操作のたびに解決が動きうる。悪性版が publish された直後にその窓が開く。`.npmrc` の `save-exact` は **これから追加する依存にしか効かない** ので、既存の範囲は手で潰す必要がある。

**d. 検証**
`pnpm install --frozen-lockfile`、`pnpm lint`、`pnpm typecheck`、`pnpm build` が通る。